### PR TITLE
Normalize Vercel edge config formatting

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,9 +6,18 @@
     }
   },
   "routes": [
-    { "src": "^/api/switch/.*", "dest": "/api/switch/[...path].js" },
-    { "src": "^/switch/(.*)$", "dest": "/api/switch/$1" },
-    { "src": "/(.*)", "dest": "/" }
+    {
+      "src": "^/api/switch/.*",
+      "dest": "/api/switch/[...path].js"
+    },
+    {
+      "src": "^/switch/(.*)$",
+      "dest": "/api/switch/$1"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/"
+    }
   ],
   "outputDirectory": "dist"
 }


### PR DESCRIPTION
## Summary
- format the Vercel routes configuration over multiple lines for readability
- ensure the Edge runtime mapping remains defined through the `functions` block and the `dist` output directory stays explicit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eee3a906608322898a8015172af71c